### PR TITLE
Support plugin config passed in by web-component-tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Note: this requires the following pull requests to be merged:
 ```js
 module.exports = {
   plugins: {
-    "web-component-tester-istanbul": {
+    istanbul: {
       dir: "./coverage",
       reporters: ["text-summary", "lcov"],
       include: [

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -7,9 +7,10 @@ var sync = true;
 * Tracks coverage objects and writes results by listening to events
 * emitted from wct test runner.
 */
-function Listener(emitter) {
 
-  this.options = emitter.options.plugins['web-component-tester-istanbul'];
+function Listener(emitter, pluginOptions) {
+
+  this.options = pluginOptions;
   this.collector = new istanbul.Collector();
   this.reporter = new istanbul.Reporter(false, this.options.dir);
   this.reporter.addAll(this.options.reporters)


### PR DESCRIPTION
Rather than reaching in to the wct config object to get this
plugin's configuration, trust wct to find the correct config
and pass it in.  This allows/requires specifying plugin config
under the `istanbul` key in `wct.conf.js`, and matches the
behavior of the wct-local and wct-sauce plugins.