### PR TITLE
Fix #5:  Update plugin for latest web-component-tester

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -3,6 +3,7 @@ var minimatch = require('minimatch');
 var fs = require('fs');
 var path = require('path');
 var istanbul = require('istanbul');
+var parseurl = require('parseurl');
 
 // istanbul
 var instrumenter = new istanbul.Instrumenter({
@@ -12,12 +13,11 @@ var instrumenter = new istanbul.Instrumenter({
 // helpers
 var cache = {}
 
-function instrumentAsset(root, req){
+function instrumentAsset(assetPath, req){
     var asset = req.url;
     var code;
 
     if ( !cache[asset] ){
-        var assetPath = path.join(root, asset);
         code = fs.readFileSync(assetPath, 'utf8');
 
         // NOTE: the instrumenter must get a file system path not a wct-webserver path.
@@ -35,8 +35,12 @@ function instrumentAsset(root, req){
  * configuration of coverage
  */
 function coverageMiddleware(root, options, emitter) {
+  var mappings = emitter.options.webserver.pathMappings;
+  var waterfall = _buildWaterfall(mappings, root);
+
   return function(req, res, next) {
-    var path = req.url;
+    var absolutePath = _getFilePathFromWaterfall(waterfall, req);
+    var relativePath = absolutePath.replace(root, '');
 
     // always ignore platform files in addition to user's blacklist
     var blacklist = ['/web-component-tester/*'].concat(options.exclude);
@@ -46,14 +50,15 @@ function coverageMiddleware(root, options, emitter) {
     this.root = root;
 
     // check asset against rules
-    var process = match(path, whitelist) && !match(path, blacklist);
+    var process = match(relativePath, whitelist) && !match(relativePath, blacklist);
 
     // instrument unfiltered assets
     if ( process ) {
-      emitter.emit('log:debug', 'coverage', 'instrument', path);
-      return res.send( instrumentAsset(this.root, req) );
+      emitter.emit('log:debug', 'coverage', 'instrument', relativePath);
+
+      return res.send( instrumentAsset(absolutePath, req) );
     } else {
-      emitter.emit('log:debug', 'coverage', 'skip      ', path);
+      emitter.emit('log:debug', 'coverage', 'skip      ', relativePath);
       return next();
     }
   };
@@ -64,6 +69,34 @@ function coverageMiddleware(root, options, emitter) {
  */
 function match(str, rules) {
     return _.any(rules, minimatch.bind(null, str));
+}
+
+function _getFilePathFromWaterfall(waterfall, request) {
+  var requestPath = parseurl(request).pathname;
+  var pathLookup = _.find(waterfall, function(pathLookup) {
+    return requestPath.indexOf(pathLookup.prefix) === 0
+  });
+
+  return requestPath.replace(pathLookup.prefix, pathLookup.target);
+}
+
+// Lifted from https://github.com/PolymerLabs/serve-waterfall
+/**
+ * @param {Mappings} mappings The mappings to serve.
+ * @param {string} root The root directory paths are relative to.
+ * @return {Array<{prefix: string, target: string}>}
+ */
+function _buildWaterfall(pathLookups, root) {
+  var basename = path.basename(root);
+  var waterfall = _.map(pathLookups, function(pathLookup) {
+      var prefix = Object.keys(pathLookup)[0];
+      return {
+        prefix: prefix.replace('<basename>', basename),
+        target: path.resolve(root, pathLookup[prefix]),
+      };
+    });
+
+  return waterfall;
 }
 
 module.exports = coverageMiddleware;

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -15,7 +15,9 @@ function Listener(emitter) {
   this.reporter.addAll(this.options.reporters)
 
   emitter.on('sub-suite-end', function(browser, data) {
-    this.collector.add(data.__coverage__);
+    if (data.__coverage__) {
+      this.collector.add(data.__coverage__);
+    }
   }.bind(this));
 
   emitter.on('run-end', function(error) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "istanbul": "^0.3.2",
     "lodash": "^2.4.1",
-    "minimatch": "^1.0.0"
+    "minimatch": "^1.0.0",
+    "parseurl": "^1.3.0"
   },
   "wct-plugin": {
     "cli-options": {


### PR DESCRIPTION
These changes partially fix #5; the complete fix is dependent on Polymer/web-component-tester#211

Some time after the most recent release of this plugin, `web-component-tester` underwent a major refactor with breaking changes.  The pull request above restores the ability to collect coverage data from sub-suites; however, due to changes in the way `WCT.share` is managed, the `web-component-tester-istanbul` middleware will always receive `sub-suite-end` events that do not include coverage data, even when coverage is properly configured.

The commits to this repository:
* update the `web-component-tester-istanbul` middleware to handle changes in how files are served by `web-component-tester`
* gracefully handle the case where `sub-suite-end` events do not include coverage data

The request path to filesystem path mapping code replicates [logic from the `serve-waterfall` module](https://github.com/PolymerLabs/serve-waterfall/blob/07dfe5bf28ed4916fa83078ad25d6240d681c24b/lib/index.js#L87)