### PR TITLE
Added support for code coverage against HTML

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var path = require('path');
 var istanbul = require('istanbul');
 var parseurl = require('parseurl');
+var scriptHook = require('html-script-hook');
 
 // istanbul
 var instrumenter = new istanbul.Instrumenter({
@@ -11,7 +12,24 @@ var instrumenter = new istanbul.Instrumenter({
 });
 
 // helpers
-var cache = {}
+var cache = {};
+
+function instrumentHtml(htmlFilePath, req){
+  var asset = req.url;
+  var code;
+
+  if ( !cache[asset] ){
+    html = fs.readFileSync(htmlFilePath, 'utf8');
+
+    cache[asset] = scriptHook (html, {scriptCallback: gotScript});
+  }
+
+  function gotScript(code, loc) {
+    return instrumenter.instrumentSync(code, htmlFilePath);
+  }
+
+  return cache[asset];
+}
 
 function instrumentAsset(assetPath, req){
     var asset = req.url;
@@ -56,13 +74,18 @@ function coverageMiddleware(root, options, emitter) {
     if ( process ) {
       emitter.emit('log:debug', 'coverage', 'instrument', relativePath);
 
+      if (absolutePath.match(/\.htm(l)?$/)) {
+        var html = instrumentHtml(absolutePath, req);
+        return res.send( html );
+      }
+
       return res.send( instrumentAsset(absolutePath, req) );
     } else {
       emitter.emit('log:debug', 'coverage', 'skip      ', relativePath);
       return next();
     }
   };
-};
+}
 
 /**
  * Returns true if the supplied string mini-matches any of the supplied patterns
@@ -74,7 +97,7 @@ function match(str, rules) {
 function _getFilePathFromWaterfall(waterfall, request) {
   var requestPath = parseurl(request).pathname;
   var pathLookup = _.find(waterfall, function(pathLookup) {
-    return requestPath.indexOf(pathLookup.prefix) === 0
+    return requestPath.indexOf(pathLookup.prefix) === 0;
   });
 
   return requestPath.replace(pathLookup.prefix, pathLookup.target);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/thedeeno/web-component-tester-istanbul",
   "dependencies": {
+    "html-script-hook": "^0.7.0",
     "istanbul": "^0.3.2",
     "lodash": "^2.4.1",
     "minimatch": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/thedeeno/web-component-tester-istanbul",
   "dependencies": {
-    "html-script-hook": "^0.7.0",
+    "html-script-hook": "^0.9.1",
     "istanbul": "^0.3.2",
     "lodash": "^2.4.1",
     "minimatch": "^1.0.0",


### PR DESCRIPTION
Now supports code coverage against HTML files that have embedded `<script>` tags. Any file that is:
1. Whitelisted in the config
2. Ends in `.html` or `.htm`
3. Has a `<script>` tag that is not an import (e.g. `<script src=...>`) and has something more than whitespace
...will automatically be instrumented using [html-script-hook](https://github.com/apowers313/html-script-hook).

The code isn't very robust yet, and may choke on unexpected situations (such as `<script>` or `</script>` tags showing up in comments or strings), but it is fairly low-risk since it requires whitelisting HTML files that would otherwise break Istanbul's parser. Testing and documentation of html-script-hook is still fairly limited, but will be expanded over the next few days.

There are probably a few other things worth considering:
1. Should the instrumenting code be collapsed down to a single function (I made it two functions for clarity)
2. Should the HTML filetypes (such as `.html` and `.htm`) be configuration options? Or should whitelisting list a file type? Or is it okay the way it is?