### PR TITLE
Add support for coverage thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ your project on each test run.
 npm install web-component-tester-istanbul --saveDev
 ```
 
-## Usage
+## Basic Usage
 
 Add the following configuration to web-component-tester's config file.
 
@@ -60,3 +60,40 @@ Files to include in instrumentation.
 
 Files to exclude from instrumentation (this trumps files 'included' with
 the option above).
+
+## Coverage Thresholds
+
+In addition to measuring coverage, this plugin can be used to enforce
+coverage thresholds.  If coverage does not meet the configured thresholds,
+then the test run will fail, even if all tests passed.
+
+This requires specifying the `thresholds` option for the plugin
+
+### Example
+
+The following configuration will cause the test run to fail if less
+than 100% of the statements in instrumented files are covered by
+tests.
+
+```js
+module.exports = {
+  plugins: {
+    istanbul: {
+      dir: "./coverage",
+      reporters: ["text-summary", "lcov"],
+      include: [
+        "**/*.js"
+      ],
+      exclude: [
+        "/polymer/polymer.js",
+        "/platform/platform.js"
+      ],
+      thresholds: {
+        global: {
+          statements: 100
+        }
+      }
+    }
+  }
+}
+```

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,6 +1,6 @@
-var _ = require('lodash');
 var middleware = require('./middleware');
 var istanbul = require('istanbul');
+var Validator = require('./validator');
 var sync = true;
 
 /**
@@ -13,6 +13,7 @@ function Listener(emitter, pluginOptions) {
   this.options = pluginOptions;
   this.collector = new istanbul.Collector();
   this.reporter = new istanbul.Reporter(false, this.options.dir);
+  this.validator = new Validator(this.options.thresholds);
   this.reporter.addAll(this.options.reporters)
 
   emitter.on('sub-suite-end', function(browser, data) {
@@ -24,6 +25,10 @@ function Listener(emitter, pluginOptions) {
   emitter.on('run-end', function(error) {
     if (!error) {
       this.reporter.write(this.collector, sync, function() {});
+
+      if (!validator.validate(this.collector)) {
+        throw new Error('Coverage failed');
+      }
     }
   }.bind(this));
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,0 +1,46 @@
+var _ = require('lodash');
+var checker = require('istanbul-threshold-checker');
+
+function Validator(thresholds) {
+  console.log('Received ' + JSON.stringify(thresholds));
+  this.thresholds = thresholds || {};
+}
+
+Validator.prototype.validate = function(collector) {
+  var finalCoverage = collector.getFinalCoverage();
+  var results = checker.checkFailures(this.thresholds, finalCoverage);
+
+  var thresholdMet = function(coverage) {
+    var thresholdMet = true;
+    var expectedValue;
+
+    if (coverage.global && coverage.global.failed) {
+      expectedValue = this.thresholds['global'][coverage.type] || this.thresholds['global']
+
+      console.log('Coverage for ' + coverage.type +
+        ' ('  + coverage.global.value + '%)' +
+        ' does not meet configured threshold (' +
+        expectedValue + '%) ');
+      thresholdMet = false;
+    }
+
+    if (coverage.each && coverage.each.failed) {
+      expectedValue = this.thresholds['each'][coverage.type] || this.thresholds['each']
+
+      console.log('Coverage threshold (' +
+        expectedValue + '%) ' + 'not met for ' +
+        coverage.type + ' in files: \n  ' +
+        coverage.each.failures.join('\n  '));
+      thresholdMet = false;
+    }
+
+    return thresholdMet;
+  }.bind(this);
+
+  return _.chain(results)
+    .map(thresholdMet)
+    .reduce(function(memo, valid) { return memo && valid; }, true)
+    .value();
+}
+
+module.exports = Validator;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/thedeeno/web-component-tester-istanbul",
   "dependencies": {
     "istanbul": "^0.3.2",
+    "istanbul-threshold-checker": "^0.1.0",
     "lodash": "^2.4.1",
     "minimatch": "^1.0.0",
     "parseurl": "^1.3.0"


### PR DESCRIPTION
This adds the ability to specify a `thresholds` option in the plugin config so that `wct` will fail when coverage does not meet the configured thresholds, even if all tests pass.