### PR TITLE
Fixed physcial path problem when the prefix ends with '/'.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -88,6 +88,13 @@ function coverageMiddleware(root, options, emitter) {
 }
 
 /**
+ * Clears the instrumented code cache
+ */
+function cacheClear() {
+  cache = {};
+}
+
+/**
  * Returns true if the supplied string mini-matches any of the supplied patterns
  */
 function match(str, rules) {
@@ -124,4 +131,7 @@ function _buildWaterfall(pathLookups, root) {
   return waterfall;
 }
 
-module.exports = coverageMiddleware;
+module.exports = {
+  middleware: coverageMiddleware,
+  cacheClear: cacheClear
+};

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -111,6 +111,7 @@ function _getFilePathFromWaterfall(waterfall, request) {
  */
 function _buildWaterfall(pathLookups, root) {
   var basename = path.basename(root);
+
   var waterfall = _.map(pathLookups, function(pathLookup) {
       var prefix = Object.keys(pathLookup)[0];
       var suffix = (_.endsWith(prefix, '/')) ? '/' : '';

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -113,9 +113,10 @@ function _buildWaterfall(pathLookups, root) {
   var basename = path.basename(root);
   var waterfall = _.map(pathLookups, function(pathLookup) {
       var prefix = Object.keys(pathLookup)[0];
+      var suffix = (_.endsWith(prefix, '/')) ? '/' : '';
       return {
         prefix: prefix.replace('<basename>', basename),
-        target: path.resolve(root, pathLookup[prefix]),
+        target: path.resolve(root, pathLookup[prefix]) + suffix,
       };
     });
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -23,6 +23,8 @@ function Listener(emitter, pluginOptions) {
   }.bind(this));
 
   emitter.on('run-end', function(error) {
+    middleware.cacheClear();
+
     if (!error) {
       this.reporter.write(this.collector, sync, function() {});
 
@@ -33,7 +35,7 @@ function Listener(emitter, pluginOptions) {
   }.bind(this));
 
   emitter.hook('prepare:webserver', function(express, done){
-    express.use(middleware(emitter.options.root, this.options, emitter));
+    express.use(middleware.middleware(emitter.options.root, this.options, emitter));
     done();
   }.bind(this));
 


### PR DESCRIPTION
On our project we encountered a problem with relative vs physical paths. The prefix on our assets resolved to '/' and was replaced on physical path. So the component threw exceptions trying to load files that had an incorrect path. 

For example: /mycomponent/file-to-test.html was being read as /mycomponentfile-to-test.html
