### PR TITLE
Do not overwrite the test result with the coverage report

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -24,6 +24,8 @@ function Listener(emitter, pluginOptions) {
 
   emitter.on('run-end', function(error) {
     if (!error) {
+      // Log a new line to not overwrite the test results outputted by WCT
+      console.log('\n');
       this.reporter.write(this.collector, sync, function() {});
 
       if (!validator.validate(this.collector)) {


### PR DESCRIPTION
Without this new line, the coverage report would be outputted on top of the test results of WCT. Now, it will be outputted just below the test results.