### PR TITLE
Allow writing results on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ module.exports = {
 
 Below are the available configuration options:
 
+### writeOnlyOnSuccess `false`
+Set to `true` to write coverage only if all tests pass  
+
 ### dir
 
 The directory to write coverage reports to.

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -24,15 +24,16 @@ function Listener(emitter, pluginOptions) {
 
   emitter.on('run-end', function(error) {
     middleware.cacheClear();
+    if (error && this.options.onlyWriteSuccess) {
+      throw Error("Tests failed. Not writing coverage report.");
+    }
 
-    if (!error) {
-      // Log a new line to not overwrite the test results outputted by WCT
-      console.log('\n');
-      this.reporter.write(this.collector, sync, function() {});
+    // Log a new line to not overwrite the test results outputted by WCT
+    console.log('\n');
+    this.reporter.write(this.collector, sync, function() {});
 
-      if (!validator.validate(this.collector)) {
-        throw new Error('Coverage failed');
-      }
+    if (!validator.validate(this.collector)) {
+      throw new Error('Coverage failed');
     }
   }.bind(this));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-tester-istanbul",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Instanbul coverage reporting for projects being tested by web-component-tester",
   "main": "lib/plugin.js",
   "scripts": {


### PR DESCRIPTION
This would be useful in order to see coverage results even if some tests fail, and would allow plugins—specifically SonarQube's generic execution—to consume the data for analysis.