### PR TITLE
Fixes #38: Update to support wct 6.4.0+ & polyserve

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -53,12 +53,9 @@ function instrumentAsset(assetPath, req){
  * configuration of coverage
  */
 function coverageMiddleware(root, options, emitter) {
-  var mappings = emitter.options.webserver.pathMappings;
-  var waterfall = _buildWaterfall(mappings, root);
-
   return function(req, res, next) {
-    var absolutePath = _getFilePathFromWaterfall(waterfall, req);
-    var relativePath = absolutePath.replace(root, '');
+    var relativePath = req.url.substring(req.url.lastIndexOf('/'));
+    var absolutePath = root + relativePath
 
     // always ignore platform files in addition to user's blacklist
     var blacklist = ['/web-component-tester/*'].concat(options.exclude);
@@ -99,36 +96,6 @@ function cacheClear() {
  */
 function match(str, rules) {
     return _.some(rules, minimatch.bind(null, str));
-}
-
-function _getFilePathFromWaterfall(waterfall, request) {
-  var requestPath = parseurl(request).pathname;
-  var pathLookup = _.find(waterfall, function(pathLookup) {
-    return requestPath.indexOf(pathLookup.prefix) === 0;
-  });
-
-  return requestPath.replace(pathLookup.prefix, pathLookup.target);
-}
-
-// Lifted from https://github.com/PolymerLabs/serve-waterfall
-/**
- * @param {Mappings} mappings The mappings to serve.
- * @param {string} root The root directory paths are relative to.
- * @return {Array<{prefix: string, target: string}>}
- */
-function _buildWaterfall(pathLookups, root) {
-  var basename = path.basename(root);
-
-  var waterfall = _.map(pathLookups, function(pathLookup) {
-      var prefix = Object.keys(pathLookup)[0];
-      var suffix = (_.endsWith(prefix, '/')) ? '/' : '';
-      return {
-        prefix: prefix.replace('<basename>', basename),
-        target: path.resolve(root, pathLookup[prefix]) + suffix,
-      };
-    });
-
-  return waterfall;
 }
 
 module.exports = {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,5 +1,6 @@
-var middleware = require('./middleware');
+var express = require('express')
 var istanbul = require('istanbul');
+var middleware = require('./middleware');
 var Validator = require('./validator');
 var sync = true;
 
@@ -36,8 +37,11 @@ function Listener(emitter, pluginOptions) {
     }
   }.bind(this));
 
-  emitter.hook('prepare:webserver', function(express, done){
-    express.use(middleware.middleware(emitter.options.root, this.options, emitter));
+  emitter.hook('define:webserver', function (app, replacePolyserveApp, options, done) {
+    var instrumentedApp = express();
+    instrumentedApp.use(middleware.middleware(emitter.options.root, this.options, emitter));
+    instrumentedApp.use(app);
+    replacePolyserveApp(instrumentedApp);
     done();
   }.bind(this));
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/thedeeno/web-component-tester-istanbul",
   "dependencies": {
+    "express": "^4.15.3",
     "html-script-hook": "^0.10.0",
     "istanbul": "^0.4.0",
     "istanbul-threshold-checker": "^0.1.0",


### PR DESCRIPTION
When `wct` moved from `serve-waterfall` to `polyserve`, it broke
this plugin's usage of the `prepare:webserver` hook.  With newer
versions of `wct`, the app used by `wct` to serve component files
has a wildcard request handler registered that prevents calling
the instrumentation middleware.

Version 6.4.0 of `wct` adds a new `define:webserver` hook so that
plugins can inject middleware to be executed before the `polyserve`
wildcard handler.

This replaces the `prepare:webserver` handler with one for the new
`define:webserver` event, allowing this plugin to instrument code
on the fly again.

Also fixes #41