### PR TITLE
Fixed plugin to use it with web-component-tester version >= 6.4.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ module.exports = {
         "**/*.js"
       ],
       exclude: [
-        "/polymer/polymer.js",
-        "/platform/platform.js"
+        "polymer/polymer.js",
+        "platform/platform.js"
       ]
     }
   }
@@ -81,8 +81,8 @@ module.exports = {
         "**/*.js"
       ],
       exclude: [
-        "/polymer/polymer.js",
-        "/platform/platform.js"
+        "polymer/polymer.js",
+        "platform/platform.js"
       ],
       thresholds: {
         global: {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,21 +1,20 @@
-var _ = require('lodash');
-var minimatch = require('minimatch');
-var fs = require('fs');
-var path = require('path');
-var istanbul = require('istanbul');
-var parseurl = require('parseurl');
-var scriptHook = require('html-script-hook');
+const _ = require('lodash');
+const minimatch = require('minimatch');
+const fs = require('fs');
+const path = require('path');
+const istanbul = require('istanbul');
+const scriptHook = require('html-script-hook');
 
 // istanbul
-var instrumenter = new istanbul.Instrumenter({
+const instrumenter = new istanbul.Instrumenter({
   coverageVariable: "WCT.share.__coverage__"
 });
 
 // helpers
 var cache = {};
 
-function instrumentHtml(htmlFilePath, req){
-  var asset = req.url;
+const instrumentHtml = (htmlFilePath) => {
+  var asset = htmlFilePath;
   var code;
 
   if ( !cache[asset] ){
@@ -29,11 +28,15 @@ function instrumentHtml(htmlFilePath, req){
   }
 
   return cache[asset];
-}
+};
 
-function instrumentAsset(assetPath, req){
-    var asset = req.url;
-    var code;
+const instrumentAsset = (assetPath) => {
+    const asset = assetPath;
+    let code;
+
+    if (!fs.existsSync(assetPath)) {
+      return;
+    }
 
     if ( !cache[asset] ){
         code = fs.readFileSync(assetPath, 'utf8');
@@ -48,90 +51,119 @@ function instrumentAsset(assetPath, req){
     return cache[asset];
 }
 
+
 /**
  * Middleware that serves an instrumented asset based on user
  * configuration of coverage
  */
-function coverageMiddleware(root, options, emitter) {
-  var mappings = emitter.options.webserver.pathMappings;
-  var waterfall = _buildWaterfall(mappings, root);
+const coverageMiddleware = (root, options, wctOpts, emitter) => {
+  const clientRoot = emitter.options.clientOptions.root;
+  const pkgName = wctOpts.packageName;
 
-  return function(req, res, next) {
-    var absolutePath = _getFilePathFromWaterfall(waterfall, req);
-    var relativePath = absolutePath.replace(root, '');
+  return (req, res, next) => {
+    let relativePath = req.url.replace(clientRoot, '');
 
-    // always ignore platform files in addition to user's blacklist
-    var blacklist = ['/web-component-tester/*'].concat(options.exclude);
-    var whitelist = options.include;
+    // we parse the files that where in the component path (pkgName)
+    if (relativePath.startsWith(pkgName)) {
+      relativePath = relativePath.replace(path.join(pkgName, path.sep), '');
 
-    // cache the webserver root for user supplied instrumenter
-    this.root = root;
+      // check asset against rules
+      const process = pathMatchesOpt(relativePath, options);
 
-    // check asset against rules
-    var process = match(relativePath, whitelist) && !match(relativePath, blacklist);
+      const absolutePath = path.join(root, relativePath);
 
-    // instrument unfiltered assets
-    if ( process ) {
-      emitter.emit('log:debug', 'coverage', 'instrument', relativePath);
-
-      if (absolutePath.match(/\.htm(l)?$/)) {
-        var html = instrumentHtml(absolutePath, req);
-        return res.send( html );
+      // instrument unfiltered assets
+      if ( process ) {
+        if (absolutePath.match(/\.htm(l)?$/)) {
+          let html = instrumentHtml(absolutePath);
+          if (html) {
+            emitter.emit('log:debug', 'coverage', 'instrument', absolutePath);
+            return res.send(html);
+          }
+        } else {
+          let instrAsset = instrumentAsset(absolutePath);
+          if (instrAsset) {
+            emitter.emit('log:debug', 'coverage', 'instrument', absolutePath);
+            return res.send(instrAsset);
+          }
+        }
       }
-
-      return res.send( instrumentAsset(absolutePath, req) );
-    } else {
-      emitter.emit('log:debug', 'coverage', 'skip      ', relativePath);
-      return next();
     }
+    emitter.emit('log:debug', 'coverage', 'skip      ', relativePath);
+    return next();
   };
-}
+};
 
 /**
  * Clears the instrumented code cache
  */
-function cacheClear() {
+const cacheClear = () => {
   cache = {};
-}
+};
 
 /**
  * Returns true if the supplied string mini-matches any of the supplied patterns
  */
-function match(str, rules) {
+const match = (str, rules) => {
     return _.some(rules, minimatch.bind(null, str));
-}
+};
 
-function _getFilePathFromWaterfall(waterfall, request) {
-  var requestPath = parseurl(request).pathname;
-  var pathLookup = _.find(waterfall, function(pathLookup) {
-    return requestPath.indexOf(pathLookup.prefix) === 0;
-  });
-
-  return requestPath.replace(pathLookup.prefix, pathLookup.target);
-}
-
-// Lifted from https://github.com/PolymerLabs/serve-waterfall
 /**
- * @param {Mappings} mappings The mappings to serve.
- * @param {string} root The root directory paths are relative to.
- * @return {Array<{prefix: string, target: string}>}
+ * Returns the files in the dir parameter directory recursively.
+ * @param {String} dir: Path where it will read the files recursively.
+ * @param {List} filelist: It is used in the recursion. First time it can be undefined or empty list.
+ * @returns A list with all the files in the dir directory. 
  */
-function _buildWaterfall(pathLookups, root) {
-  var basename = path.basename(root);
+const readFilesRecursiveSync = (dir, filelist) => {
+  let files = fs.readdirSync(dir);
+  filelist = filelist || [];
+  files.forEach(function(file) {
+      if (fs.statSync(path.join(dir, file)).isDirectory()) {
+          filelist = readFilesRecursiveSync(path.join(dir, file), filelist);
+      }
+      else {
+          filelist.push(path.join(dir, file));
+      }
+  });
+  return filelist;
+};
 
-  var waterfall = _.map(pathLookups, function(pathLookup) {
-      var prefix = Object.keys(pathLookup)[0];
-      var suffix = (_.endsWith(prefix, '/')) ? '/' : '';
-      return {
-        prefix: prefix.replace('<basename>', basename),
-        target: path.resolve(root, pathLookup[prefix]) + suffix,
-      };
-    });
+/**
+ * Returns the files that have not been processed in the middleware function and that match with the options 
+ * include pattern and they don't match with the options exclude pattern.
+ * @param {String} dir: Path where we have to search the files with non coverage.
+ * @param {Object} options: 
+ */
+const getFilesNotCoveraged = (dir, options) => {
+  const listFiles = readFilesRecursiveSync(dir);
+  let cacheKeys = Object.keys(cache);
+  let result = [];
+  listFiles.forEach(
+    file => {
+      const absoluteFile = path.resolve(file);
+      if (cacheKeys.indexOf(absoluteFile) < 0) {
+        const matches = pathMatchesOpt(file.replace(path.join(dir, path.sep), ''), options);
+        if (matches) {
+          result.push(absoluteFile);
+        }
+      }
+    }
+  );
 
-  return waterfall;
+  return result;
+};
+
+function pathMatchesOpt (relativePath, options) {
+  // always ignore platform files in addition to user's blacklist
+  let blacklist = ['web-component-tester/*'].concat(options.exclude);
+  let whitelist = options.include;
+
+  // check asset against rules
+  return match(relativePath, whitelist) && !match(relativePath, blacklist);
 }
 
 module.exports = {
   middleware: coverageMiddleware,
-  cacheClear: cacheClear
+  cacheClear: cacheClear,
+  getFilesNotCoveraged: getFilesNotCoveraged
 };

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -2,24 +2,26 @@ const _ = require('lodash');
 const minimatch = require('minimatch');
 const fs = require('fs');
 const path = require('path');
+const parse5 = require('parse5');
+const dom5 = require('dom5');
+const pred = dom5.predicates;
+const strip = require('strip-comments');
 const istanbul = require('istanbul');
 
-const regexScriptHook = /<script(?![^>]*?src)[\s\S]*?>([\s\S]*?)<\/script>/gm
+const HREF_SCRIPT_PRED = pred.AND(pred.hasTagName('script'), pred.NOT(pred.hasAttr('src')));
 
 const getScriptHtmlTags = (htmlCode) => {
+  const doc = parse5.parse(htmlCode, {locationInfo: true});
+  const scriptTags = dom5.queryAll(doc, HREF_SCRIPT_PRED);
   let scriptContent = [];
-  let match = regexScriptHook.exec(htmlCode);
-  while (match != null) {
-    // matched text: match[0]
-    // match start: match.index
-    // capturing group n: match[n]
-    let content = match[1];
-    if (content.trim()) {
-      scriptContent.push(content);
+
+  scriptTags.forEach(
+    scriptTag => {
+        const content = strip(dom5.getTextContent(scriptTag)).trim();
+        scriptContent.push(content);
     }
-    match = regexScriptHook.exec(htmlCode);
-  }
-  
+  );
+
   return scriptContent.join(';');
 }
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -3,7 +3,26 @@ const minimatch = require('minimatch');
 const fs = require('fs');
 const path = require('path');
 const istanbul = require('istanbul');
-const scriptHook = require('html-script-hook');
+
+const regexScriptHook = /<script(?![^>]*?src)[\s\S]*?>([\s\S]*?)<\/script>/gm
+
+const getScriptHtmlTags = (htmlCode) => {
+  let scriptContent = [];
+  let match = regexScriptHook.exec(htmlCode);
+  while (match != null) {
+    // matched text: match[0]
+    // match start: match.index
+    // capturing group n: match[n]
+    let content = match[1];
+    if (content.trim()) {
+      scriptContent.push(content);
+    }
+    match = regexScriptHook.exec(htmlCode);
+  }
+  
+  return scriptContent.join(';');
+}
+
 
 // istanbul
 const instrumenter = new istanbul.Instrumenter({
@@ -14,17 +33,15 @@ const instrumenter = new istanbul.Instrumenter({
 var cache = {};
 
 const instrumentHtml = (htmlFilePath) => {
-  var asset = htmlFilePath;
-  var code;
+  let asset = htmlFilePath;
 
   if ( !cache[asset] ){
     html = fs.readFileSync(htmlFilePath, 'utf8');
 
-    cache[asset] = scriptHook (html, {scriptCallback: gotScript});
-  }
-
-  function gotScript(code, loc) {
-    return instrumenter.instrumentSync(code, htmlFilePath);
+    let code = getScriptHtmlTags(html);
+    if (code) {
+      cache[asset] = instrumenter.instrumentSync(code, htmlFilePath);
+    }
   }
 
   return cache[asset];

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -2,29 +2,9 @@ const _ = require('lodash');
 const minimatch = require('minimatch');
 const fs = require('fs');
 const path = require('path');
-const parse5 = require('parse5');
-const dom5 = require('dom5');
-const pred = dom5.predicates;
-const strip = require('strip-comments');
 const istanbul = require('istanbul');
-
-const HREF_SCRIPT_PRED = pred.AND(pred.hasTagName('script'), pred.NOT(pred.hasAttr('src')));
-
-const getScriptHtmlTags = (htmlCode) => {
-  const doc = parse5.parse(htmlCode, {locationInfo: true});
-  const scriptTags = dom5.queryAll(doc, HREF_SCRIPT_PRED);
-  let scriptContent = [];
-
-  scriptTags.forEach(
-    scriptTag => {
-        const content = strip(dom5.getTextContent(scriptTag)).trim();
-        scriptContent.push(content);
-    }
-  );
-
-  return scriptContent.join(';');
-}
-
+const scriptHook = require('html-script-hook');
+const stripHtmlComments = require('strip-html-comments')
 
 // istanbul
 const instrumenter = new istanbul.Instrumenter({
@@ -35,18 +15,20 @@ const instrumenter = new istanbul.Instrumenter({
 var cache = {};
 
 const instrumentHtml = (htmlFilePath) => {
-  let asset = htmlFilePath;
+  var asset = htmlFilePath;
+  var code;
 
   if ( !cache[asset] ){
-    html = fs.readFileSync(htmlFilePath, 'utf8');
+    let html = fs.readFileSync(htmlFilePath, 'utf8');
+    html = stripHtmlComments(html);
 
-    let code = getScriptHtmlTags(html);
-    if (code) {
-      cache[asset] = instrumenter.instrumentSync(code, htmlFilePath);
-    }
+    cache[asset] = scriptHook(html, {scriptCallback: gotScript});
+    return cache[asset];
   }
 
-  return cache[asset];
+  function gotScript(code, loc) {
+    return instrumenter.instrumentSync(code, htmlFilePath);
+  }
 };
 
 const instrumentAsset = (assetPath) => {
@@ -57,7 +39,7 @@ const instrumentAsset = (assetPath) => {
       return;
     }
 
-    if ( !cache[asset] ){
+    if ( !cache[asset] ) {
         code = fs.readFileSync(assetPath, 'utf8');
 
         // NOTE: the instrumenter must get a file system path not a wct-webserver path.
@@ -65,9 +47,8 @@ const instrumentAsset = (assetPath) => {
         // will error, siting that files were not found
         // (thedeeno)
         cache[asset] = instrumenter.instrumentSync(code, assetPath);
+        return cache[asset];
     }
-
-    return cache[asset];
 }
 
 /**

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -85,11 +85,12 @@ const instrumentElem = (absolutePath) => {
  * configuration of coverage
  */
 const coverageMiddleware = (root, options, wctOpts, emitter) => {
-  const clientRoot = emitter.options.clientOptions.root;
-  const pkgName = wctOpts.packageName;
+  const clientRoot = path.normalize(emitter.options.clientOptions.root);
+  const pkgName = path.normalize(wctOpts.packageName);
 
   return (req, res, next) => {
-    let relativePath = req.url.replace(clientRoot, '');
+    let normalizedReqUrl = path.normalize(req.url)
+    let relativePath = normalizedReqUrl.replace(clientRoot, '');
 
     // we parse the files that where in the component path (pkgName)
     if (relativePath.startsWith(pkgName)) {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -51,6 +51,17 @@ const instrumentAsset = (assetPath) => {
     return cache[asset];
 }
 
+/**
+ * Returns the instrumented asset depending on if the absolutePath represents an html file or not
+ * @param {String} absolutePath 
+ */
+const instrumentElem = (absolutePath) => {
+  if (absolutePath.match(/\.htm(l)?$/)) {
+    return instrumentHtml(absolutePath);
+  } else {
+    return instrumentAsset(absolutePath);
+  }
+};
 
 /**
  * Middleware that serves an instrumented asset based on user
@@ -74,18 +85,10 @@ const coverageMiddleware = (root, options, wctOpts, emitter) => {
 
       // instrument unfiltered assets
       if ( process ) {
-        if (absolutePath.match(/\.htm(l)?$/)) {
-          let html = instrumentHtml(absolutePath);
-          if (html) {
-            emitter.emit('log:debug', 'coverage', 'instrument', absolutePath);
-            return res.send(html);
-          }
-        } else {
-          let instrAsset = instrumentAsset(absolutePath);
-          if (instrAsset) {
-            emitter.emit('log:debug', 'coverage', 'instrument', absolutePath);
-            return res.send(instrAsset);
-          }
+        let asset = instrumentElem(absolutePath);
+        if (asset) {
+          emitter.emit('log:debug', 'coverage', 'instrument', absolutePath);
+          return res.send(asset);
         }
       }
     }
@@ -129,7 +132,7 @@ const readFilesRecursiveSync = (dir, filelist) => {
 };
 
 /**
- * Returns the files that have not been processed in the middleware function and that match with the options 
+ * Returns the coveraged of files that have not been processed in the middleware function and that match with the options 
  * include pattern and they don't match with the options exclude pattern.
  * @param {String} dir: Path where we have to search the files with non coverage.
  * @param {Object} options: 
@@ -144,7 +147,11 @@ const getFilesNotCoveraged = (dir, options) => {
       if (cacheKeys.indexOf(absoluteFile) < 0) {
         const matches = pathMatchesOpt(file.replace(path.join(dir, path.sep), ''), options);
         if (matches) {
-          result.push(absoluteFile);
+          let asset = instrumentElem(absoluteFile);
+          if (asset) {
+            const lastCvg = {[absoluteFile]: instrumenter.lastFileCoverage()};
+            result.push(Object.assign({}, lastCvg));
+          }
         }
       }
     }

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -23,8 +23,8 @@ const instrumentHtml = (htmlFilePath) => {
     html = stripHtmlComments(html);
 
     cache[asset] = scriptHook(html, {scriptCallback: gotScript});
-    return cache[asset];
   }
+  return cache[asset];
 
   function gotScript(code, loc) {
     return instrumenter.instrumentSync(code, htmlFilePath);
@@ -47,8 +47,8 @@ const instrumentAsset = (assetPath) => {
         // will error, siting that files were not found
         // (thedeeno)
         cache[asset] = instrumenter.instrumentSync(code, assetPath);
-        return cache[asset];
     }
+    return cache[asset];
 }
 
 /**

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -6,8 +6,6 @@ const middleware = require('./middleware');
 const Validator = require('./validator');
 const sync = true;
 
-const coverageFail = { s: {'1': 0}, statementMap: {'1': {start: {line: 0, column: 0}, end: {line: 0, column: 0}}}, f: {'1': 0}, fnMap: {'1': {name: '', line: 'All', loc: {start: { line: 1 }, end: { }} }}, b: {'1': [0]}, branchMap: {'1': {}} };
-
 /**
 * Tracks coverage objects and writes results by listening to events
 * emitted from wct test runner.
@@ -36,8 +34,7 @@ function Listener (emitter, pluginOptions) {
     const cvgAll = middleware.getFilesNotCoveraged(emitter.options.root, this.options);
     cvgAll.forEach(
       data => {
-        const obj = { [data]:  Object.assign({path: data}, coverageFail)};
-        this.collector.add(obj);
+        this.collector.add(data);
       }
     );
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -19,7 +19,7 @@ function Listener (emitter, pluginOptions) {
 
   this.options = pluginOptions;
   this.collector = new istanbul.Collector();
-  this.reporter = new istanbul.Reporter(false, path.join(emitter.options.root, this.options.dir));
+  this.reporter = new istanbul.Reporter(false, path.join(emitter.options.root || process.cwd(), this.options.dir));
   this.validator = new Validator(this.options.thresholds);
   this.reporter.addAll(this.options.reporters);
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,20 +1,29 @@
-var middleware = require('./middleware');
-var istanbul = require('istanbul');
-var Validator = require('./validator');
-var sync = true;
+const express = require('express');
+const istanbul = require('istanbul');
+const path = require('path');
+
+const middleware = require('./middleware');
+const Validator = require('./validator');
+const sync = true;
+
+const coverageFail = { s: {'1': 0}, statementMap: {'1': {start: {line: 0, column: 0}, end: {line: 0, column: 0}}}, f: {'1': 0}, fnMap: {'1': {name: '', line: 'All', loc: {start: { line: 1 }, end: { }} }}, b: {'1': [0]}, branchMap: {'1': {}} };
 
 /**
 * Tracks coverage objects and writes results by listening to events
 * emitted from wct test runner.
 */
 
-function Listener(emitter, pluginOptions) {
+/**
+ * Plugin compatible with the version 6.4.x of web-component-tester
+ */
+
+function Listener (emitter, pluginOptions) {
 
   this.options = pluginOptions;
   this.collector = new istanbul.Collector();
-  this.reporter = new istanbul.Reporter(false, this.options.dir);
+  this.reporter = new istanbul.Reporter(false, path.join(emitter.options.root, this.options.dir));
   this.validator = new Validator(this.options.thresholds);
-  this.reporter.addAll(this.options.reporters)
+  this.reporter.addAll(this.options.reporters);
 
   emitter.on('sub-suite-end', function(browser, data) {
     if (data && data.__coverage__) {
@@ -23,6 +32,16 @@ function Listener(emitter, pluginOptions) {
   }.bind(this));
 
   emitter.on('run-end', function(error) {
+    // Get files with no coverage and that matches with the options include pattern
+    const cvgAll = middleware.getFilesNotCoveraged(emitter.options.root, this.options);
+    cvgAll.forEach(
+      data => {
+        const obj = { [data]:  Object.assign({path: data}, coverageFail)};
+        this.collector.add(obj);
+      }
+    );
+
+    // Clear middleware cache
     middleware.cacheClear();
 
     if (!error) {
@@ -36,8 +55,11 @@ function Listener(emitter, pluginOptions) {
     }
   }.bind(this));
 
-  emitter.hook('prepare:webserver', function(express, done){
-    express.use(middleware.middleware(emitter.options.root, this.options, emitter));
+  emitter.hook('define:webserver', function (app, replacePolyserveApp, wctOptions, done) {
+    var instrumentedApp = express();
+    instrumentedApp.use(middleware.middleware(emitter.options.root, this.options, wctOptions, emitter));
+    instrumentedApp.use(app);
+    replacePolyserveApp(instrumentedApp);
     done();
   }.bind(this));
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,17 +1,17 @@
-var _ = require('lodash');
-var checker = require('istanbul-threshold-checker');
+const _ = require('lodash');
+const checker = require('istanbul-threshold-checker');
 
 function Validator(thresholds) {
   this.thresholds = thresholds || {};
 }
 
 Validator.prototype.validate = function(collector) {
-  var finalCoverage = collector.getFinalCoverage();
-  var results = checker.checkFailures(this.thresholds, finalCoverage);
+  let finalCoverage = collector.getFinalCoverage();
+  let results = checker.checkFailures(this.thresholds, finalCoverage);
 
-  var thresholdMet = function(coverage) {
-    var thresholdMet = true;
-    var expectedValue;
+  const thresholdMet = function(coverage) {
+    let thresholdMet = true;
+    let expectedValue;
 
     if (coverage.global && coverage.global.failed) {
       expectedValue = this.thresholds['global'][coverage.type] || this.thresholds['global']

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "homepage": "https://github.com/thedeeno/web-component-tester-istanbul",
   "dependencies": {
     "express": "^4.15.3",
-    "html-script-hook": "^0.10.0",
     "istanbul": "^0.4.0",
     "istanbul-threshold-checker": "^0.1.0",
     "lodash": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-tester-istanbul",
-  "version": "0.10.1",
+  "version": "1.0.0",
   "description": "Instanbul coverage reporting for projects being tested by web-component-tester",
   "main": "lib/plugin.js",
   "scripts": {
@@ -23,12 +23,12 @@
   },
   "homepage": "https://github.com/thedeeno/web-component-tester-istanbul",
   "dependencies": {
+    "express": "^4.15.3",
     "html-script-hook": "^0.10.0",
     "istanbul": "^0.4.0",
     "istanbul-threshold-checker": "^0.1.0",
     "lodash": "^4.0.0",
-    "minimatch": "^3.0.0",
-    "parseurl": "^1.3.0"
+    "minimatch": "^3.0.0"
   },
   "wct-plugin": {
     "cli-options": {

--- a/package.json
+++ b/package.json
@@ -23,11 +23,14 @@
   },
   "homepage": "https://github.com/thedeeno/web-component-tester-istanbul",
   "dependencies": {
+    "dom5": "^3.0.0",
     "express": "^4.15.3",
     "istanbul": "^0.4.0",
     "istanbul-threshold-checker": "^0.1.0",
     "lodash": "^4.0.0",
-    "minimatch": "^3.0.0"
+    "minimatch": "^3.0.0",
+    "parse5": "^4.0.0",
+    "strip-comments": "^0.4.4"
   },
   "wct-plugin": {
     "cli-options": {

--- a/package.json
+++ b/package.json
@@ -23,14 +23,13 @@
   },
   "homepage": "https://github.com/thedeeno/web-component-tester-istanbul",
   "dependencies": {
-    "dom5": "^3.0.0",
     "express": "^4.15.3",
+    "html-script-hook": "^1.0.0",
     "istanbul": "^0.4.0",
     "istanbul-threshold-checker": "^0.1.0",
     "lodash": "^4.0.0",
     "minimatch": "^3.0.0",
-    "parse5": "^4.0.0",
-    "strip-comments": "^0.4.4"
+    "strip-html-comments": "^1.0.0"
   },
   "wct-plugin": {
     "cli-options": {


### PR DESCRIPTION
- Replaced prepare:webserver hook event by define:webserver and replace waterfall-server by express.
- Refactor to use let and const annotations and function declarations.
- Removed unused dependencies.
- Added method to add not coverage files that match with the options.include pattern and don't match with the options.exclude pattern but this files don't be imported/used by the tests, so the coverage is 0.
- Updated the example in the README.md file, because the exclude pattern don't should start with '/' now.